### PR TITLE
Fix DMX input not working when DMA channels are already in use before

### DIFF
--- a/src/DmxInput.cpp
+++ b/src/DmxInput.cpp
@@ -146,7 +146,7 @@ void DmxInput::read_async(volatile uint8_t *buffer) {
         false
     );
 
-    dma_channel_set_irq0_enabled(_sm, true);
+    dma_channel_set_irq0_enabled(_dma_chan, true);
     irq_set_exclusive_handler(DMA_IRQ_0, dmxinput_dma_handler);
     irq_set_enabled(DMA_IRQ_0, true);
 


### PR DESCRIPTION
There's a small glitch in the DMX input code: When either DMA channels are in use before configuring a DmxInput instance, the read will fail. Reason is that not the DMA channel was given to `dma_channel_set_irq0_enabled` but instead the number of the state machine.
In the examples, those were identical by accident. In the real world, they might not always be.