### PR TITLE
Add support for Pico-SDK-based projects (= non Arduino)

### DIFF
--- a/interfaceLibForPicoSDK.cmake
+++ b/interfaceLibForPicoSDK.cmake
@@ -1,0 +1,23 @@
+## Include this file if you want to use the Pico-DMX library
+## in YOUR (Pico-C-SDK-based) project.
+
+cmake_minimum_required(VERSION 3.12)
+
+# Define the Pico-DMX library
+add_library(picodmx INTERFACE)
+
+target_sources(picodmx INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/src/DmxInput.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/DmxOutput.cpp
+)
+
+pico_generate_pio_header(picodmx
+    ${CMAKE_CURRENT_LIST_DIR}/extras/DmxInput.pio
+)
+pico_generate_pio_header(picodmx
+    ${CMAKE_CURRENT_LIST_DIR}/extras/DmxOutput.pio
+)
+
+target_include_directories(picodmx INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/src
+)

--- a/src/DmxInput.cpp
+++ b/src/DmxInput.cpp
@@ -6,9 +6,15 @@
 
 #include "DmxInput.h"
 #include "DmxInput.pio.h"
+#ifdef ARDUINO
 #include <clocks.h>
 #include <irq.h>
 #include <Arduino.h> // REMOVE ME
+#else
+#include "pico/time.h"
+#include "hardware/clocks.h"
+#include "hardware/irq.h"
+#endif
 
 bool prgm_loaded[] = {false,false};
 volatile uint prgm_offsets[] = {0,0};
@@ -108,7 +114,11 @@ void dmxinput_dma_handler() {
             dma_channel_set_write_addr(i, instance->_buf, true);
             pio_sm_exec(instance->_pio, instance->_sm, pio_encode_jmp(prgm_offsets[pio_get_index(instance->_pio)]));
             pio_sm_clear_fifos(instance->_pio, instance->_sm);
+#ifdef ARDUINO
             instance->_last_packet_timestamp = millis();
+#else
+            instance->_last_packet_timestamp = to_ms_since_boot(get_absolute_time());
+#endif
         }
     }
 }

--- a/src/DmxInput.h
+++ b/src/DmxInput.h
@@ -8,8 +8,13 @@
 #ifndef DMX_INPUT_H
 #define DMX_INPUT_H
 
+#ifdef ARDUINO
 #include <dma.h>
 #include <pio.h>
+#else
+#include "hardware/dma.h"
+#include "hardware/pio.h"
+#endif
 
 #define DMX_UNIVERSE_SIZE 512
 #define DMX_SM_FREQ 1000000

--- a/src/DmxOutput.cpp
+++ b/src/DmxOutput.cpp
@@ -7,8 +7,13 @@
 
 #include "DmxOutput.h"
 #include "DmxOutput.pio.h"
+#ifdef ARDUINO
 #include <clocks.h>
 #include <irq.h>
+#else
+#include "hardware/clocks.h"
+#include "hardware/irq.h"
+#endif
 
 DmxOutput::return_code DmxOutput::begin(uint pin, PIO pio)
 {

--- a/src/DmxOutput.h
+++ b/src/DmxOutput.h
@@ -7,8 +7,13 @@
 #ifndef DMX_OUTPUT_H
 #define DMX_OUTPUT_H
 
+#ifdef ARDUINO
 #include <dma.h>
 #include <pio.h>
+#else
+#include "hardware/dma.h"
+#include "hardware/pio.h"
+#endif
 
 #define DMX_UNIVERSE_SIZE 512
 #define DMX_SM_FREQ 1000000


### PR DESCRIPTION
This PR modifies some `#includes` so that they are only active when building for Arduino (not actually tested, to be honest) so different `#includes` are being used when compiling this library outside of Arduino, for example using the Pico C/C++ SDK.
Furthermore, a cmake-file is added that allows the library to be easily used in pico-sdk-based projects.