### PR TITLE
DmxInput: Pass the instance as parameter to the callback so that the callee knows which instance just received data

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ Use the `.read(...)` method to read the 3 channels for our RGB fixture into our 
 
 The `.read(...)` method blocks until it receives a valid DMX packet. Much like the `DmxOutput`, the zero'th channel in the DMX packet is the start code. Unless you want to mess around with other protocols such as RDM, the start code can safely be ignored.
 
-As an alternative to the blocking `.read(...)` method, you can also start asynchronous buffer updates via the 
- `.read_async(...)` method. This way, the buffer is automatically updated when DMX data comes in.
- Optionally, you can also pass a pointer to a callback-function that will be called everytime a new DMX 
- frame has been received, processed and has been written to the buffer.
+As an alternative to the blocking `.read(...)` method, you can also start asynchronous buffer updates via the `.read_async(...)` method. This way, the buffer is automatically updated when DMX data comes in.
+Optionally, you can also pass a pointer to a callback-function that will be called everytime a new DMX frame has been received, processed and has been written to the buffer. This callback-function will be called with one parameter which is the instance that has received the new data. This way, you can use one callback-function to react on data from multiple universes. See this example below:
 
 ```C++
-   void dmxDataRecevied() {
-     // A DMX frame has been received. Toggle some LED
-     digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
+   void __isr dmxDataRecevied(DmxInput* instance) {
+     // A DMX frame has been received :-)
+     // Toggle some LED, depending on which pin the data arrived
+     uint ledPin = instance->pin() + 8;
+     digitalWrite(ledPin, !digitalRead(ledPin));
    }
 
    myDmxInput.read_async(buffer, dmxDataRecevied);

--- a/src/DmxInput.cpp
+++ b/src/DmxInput.cpp
@@ -122,13 +122,13 @@ void dmxinput_dma_handler() {
 #endif
             // Trigger the callback if we have one
             if (instance->_cb != nullptr) {
-                (*(instance->_cb))();
+                (*(instance->_cb))((DmxInput*)instance);
             }
         }
     }
 }
 
-void DmxInput::read_async(volatile uint8_t *buffer, void (*inputUpdatedCallback)(void)) {
+void DmxInput::read_async(volatile uint8_t *buffer, void (*inputUpdatedCallback)(DmxInput*)) {
 
     _buf = buffer;
     if (inputUpdatedCallback!=nullptr) {
@@ -178,6 +178,10 @@ void DmxInput::read_async(volatile uint8_t *buffer, void (*inputUpdatedCallback)
 
 unsigned long DmxInput::latest_packet_timestamp() {
     return _last_packet_timestamp;
+}
+
+uint DmxInput::pin() {
+    return _pin;
 }
 
 void DmxInput::end()

--- a/src/DmxInput.h
+++ b/src/DmxInput.h
@@ -35,7 +35,7 @@ public:
     volatile uint _sm;
     volatile uint _dma_chan;
     volatile unsigned long _last_packet_timestamp=0;
-    void (*_cb)(void);
+    void (*_cb)(DmxInput*);
     /*
         All different return codes for the DMX class. Only the SUCCESS
         Return code guarantees that the DMX output instance was properly configured
@@ -86,14 +86,19 @@ public:
         If you want to be notified whenever a new DMX frame has been received,
         provide a callback function that will be called without arguments.
     */
-    void read_async(volatile uint8_t *buffer, void (*inputUpdatedCallback)(void) = nullptr);
+    void read_async(volatile uint8_t *buffer, void (*inputUpdatedCallback)(DmxInput* instance) = nullptr);
 
     /*
         Get the timestamp (like millis()) from the moment the latest dmx packet was received.
         May be used to detect if the dmx signal has stopped coming in.
     */
-
     unsigned long latest_packet_timestamp();
+
+    /*
+        Get the pin this instance is listening on
+    */
+    uint pin();
+
 
     /*
         De-inits the DMX input instance. Releases PIO resources. 


### PR DESCRIPTION
The callback that has been added to `read_async` in #14 is a nice addition. However, when reading data on multiple universes, one also needs to provide multiple callback functions, one for each universe / instance of DmxInput.
This PR adds a pointer to the DmxInput-instance as an parameter to the callback-function. This way, the user only needs to provide one callback for incoming DMX-data and the check, on which universe/pin the data arrived can be done inside this one callback.
To make things even easier, a new public method is added to DmxInput that returns the pin number the instance of DmxInput is listening on.
The README-file has also been adapted ;)