### PR TITLE
Add support to `arduino-pico` and `mbed_nano` core

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=DMX protocol library for the RaspberryPi Pico
 paragraph=A library for inputting and outputting the DMX protocol for entertainment lighting on the RaspberryPi Pico using the Programmable IO (PIO) feature of the Pico
 category=Signal Input/Output
 url=https://github.com/jostlowe/Pico-DMX
-architectures=rp2040, mbed_rp2040
+architectures=rp2040, mbed_rp2040, mbed_nano

--- a/src/DmxInput.cpp
+++ b/src/DmxInput.cpp
@@ -6,14 +6,15 @@
 
 #include "DmxInput.h"
 #include "DmxInput.pio.h"
-#ifdef ARDUINO
-#include <clocks.h>
-#include <irq.h>
-#include <Arduino.h> // REMOVE ME
+
+#if defined(ARDUINO_ARCH_MBED)
+  #include <clocks.h>
+  #include <irq.h>
+  #include <Arduino.h> // REMOVE ME
 #else
-#include "pico/time.h"
-#include "hardware/clocks.h"
-#include "hardware/irq.h"
+  #include "pico/time.h"
+  #include "hardware/clocks.h"
+  #include "hardware/irq.h"
 #endif
 
 bool prgm_loaded[] = {false,false};

--- a/src/DmxInput.h
+++ b/src/DmxInput.h
@@ -12,7 +12,9 @@
   #include <dma.h>
   #include <pio.h>
 #else
-  #include <Arduino.h>
+  #ifdef ARDUINO
+    #include <Arduino.h>
+  #endif
   #include "hardware/dma.h"
   #include "hardware/pio.h"
 #endif

--- a/src/DmxInput.h
+++ b/src/DmxInput.h
@@ -8,12 +8,13 @@
 #ifndef DMX_INPUT_H
 #define DMX_INPUT_H
 
-#ifdef ARDUINO
-#include <dma.h>
-#include <pio.h>
+#if defined(ARDUINO_ARCH_MBED)
+  #include <dma.h>
+  #include <pio.h>
 #else
-#include "hardware/dma.h"
-#include "hardware/pio.h"
+  #include <Arduino.h>
+  #include "hardware/dma.h"
+  #include "hardware/pio.h"
 #endif
 
 #define DMX_UNIVERSE_SIZE 512

--- a/src/DmxOutput.cpp
+++ b/src/DmxOutput.cpp
@@ -7,12 +7,13 @@
 
 #include "DmxOutput.h"
 #include "DmxOutput.pio.h"
-#ifdef ARDUINO
-#include <clocks.h>
-#include <irq.h>
+
+#if defined(ARDUINO_ARCH_MBED)
+  #include <clocks.h>
+  #include <irq.h>
 #else
-#include "hardware/clocks.h"
-#include "hardware/irq.h"
+  #include "hardware/clocks.h"
+  #include "hardware/irq.h"
 #endif
 
 DmxOutput::return_code DmxOutput::begin(uint pin, PIO pio)

--- a/src/DmxOutput.h
+++ b/src/DmxOutput.h
@@ -11,7 +11,9 @@
   #include <dma.h>
   #include <pio.h>
 #else
-  #include <Arduino.h>
+  #ifdef ARDUINO
+    #include <Arduino.h>
+  #endif
   #include "hardware/dma.h"
   #include "hardware/pio.h"
 #endif

--- a/src/DmxOutput.h
+++ b/src/DmxOutput.h
@@ -7,12 +7,13 @@
 #ifndef DMX_OUTPUT_H
 #define DMX_OUTPUT_H
 
-#ifdef ARDUINO
-#include <dma.h>
-#include <pio.h>
+#if defined(ARDUINO_ARCH_MBED)
+  #include <dma.h>
+  #include <pio.h>
 #else
-#include "hardware/dma.h"
-#include "hardware/pio.h"
+  #include <Arduino.h>
+  #include "hardware/dma.h"
+  #include "hardware/pio.h"
 #endif
 
 #define DMX_UNIVERSE_SIZE 512


### PR DESCRIPTION
1. Add support to [Earle Philhower's arduino-pico core](https://github.com/earlephilhower/arduino-pico)
2. Add support to `Nano_RP2040_Connect` using `mbed_nano` core

---

Compile Results for `Nano_RP2040_Connect`using [Earle Philhower's arduino-pico core](https://github.com/earlephilhower/arduino-pico)

![Selection_104](https://user-images.githubusercontent.com/57012152/154868777-26614d78-4d62-40f1-9a37-da006a192114.png)



