### PR TITLE
Fix hardware/pio.h: No such file

### DIFF
--- a/interfaceLibForPicoSDK.cmake
+++ b/interfaceLibForPicoSDK.cmake
@@ -1,10 +1,15 @@
-## Include this file if you want to use the Pico-DMX library
-## in YOUR (Pico-C-SDK-based) project.
+# # Include this file if you want to use the Pico-DMX library
+# # in YOUR (Pico-C-SDK-based) project.
 
 cmake_minimum_required(VERSION 3.12)
 
 # Define the Pico-DMX library
 add_library(picodmx INTERFACE)
+
+target_link_libraries(picodmx INTERFACE
+    pico_stdlib
+    hardware_pio
+)
 
 target_sources(picodmx INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/src/DmxInput.cpp


### PR DESCRIPTION
If you import the library using `interfaceLibForPicoSDK.cmake` the api was not able to access `hardware/pio.h`

[Error thrown]
```
./dependencies/pico-dmx/src/DmxOutput.h:18:12: fatal error: hardware/pio.h: No such file or directory
18 |   #include "hardware/pio.h"
```

Error is resolved by adding the library to the picodmx interface
```cmake
target_sources(picodmx INTERFACE
    ${CMAKE_CURRENT_LIST_DIR}/src/DmxInput.cpp
    ${CMAKE_CURRENT_LIST_DIR}/src/DmxOutput.cpp
)
```